### PR TITLE
Panel titles and subtitles do not catch punctation (fixes #267)

### DIFF
--- a/verto/processors/PanelBlockProcessor.py
+++ b/verto/processors/PanelBlockProcessor.py
@@ -30,19 +30,19 @@ class PanelBlockProcessor(GenericContainerBlockProcessor):
         blocks = []
 
         argument = 'title'
-        title_r = re.compile(r'(^|\n)# ((\w| )*)(?P<args>)')
+        title_r = re.compile(r'^#(?!#+)\s?(?P<title>.*?)$')
         title = title_r.search(content_blocks[0])
         if title:
-            extra_args[argument] = title.groups()[1]
+            extra_args[argument] = title.group(argument)
         else:
             raise PanelMissingTitleError(self.processor, argument)
 
         argument = 'subtitle'
         if argument_values.get(argument) == 'true':
-            subtitle_r = re.compile(r'(^|\n)## ((\w| )*)(?P<args>)')
+            subtitle_r = re.compile(r'^##(?!#+)\s?(?P<subtitle>.*?)$')
             subtitle = subtitle_r.search(content_blocks[1])
             if subtitle:
-                extra_args[argument] = subtitle.groups()[1]
+                extra_args[argument] = subtitle.group(argument)
                 blocks = content_blocks[2:]
             else:
                 raise PanelMissingSubtitleError(self.processor, argument)

--- a/verto/tests/HeadingTest.py
+++ b/verto/tests/HeadingTest.py
@@ -40,6 +40,41 @@ class HeadingTest(ProcessorTest):
         tree = self.verto_extension.get_heading_tree()
         self.assertIsNone(tree)
 
+    def test_no_whitespace(self):
+        '''An example of usage with no whitespace between heading level and text.
+        '''
+        test_string = self.read_test_file(self.processor_name, 'no_whitespace.md')
+        blocks = self.to_blocks(test_string)
+
+        self.assertListEqual([True, True, True], [HeadingBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks], msg='"{}"'.format(test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'no_whitespace_expected.html', strip=True)
+        self.assertEqual(expected_string, converted_test_string)
+
+        tree = self.verto_extension.get_heading_tree()
+        expected_tree = (HeadingNode(title='This is an H1',
+                                    title_slug='this-is-an-h1',
+                                    level=1,
+                                    children=(
+                                        HeadingNode(
+                                            title='This is an H2',
+                                            title_slug='this-is-an-h2',
+                                            level=2,
+                                            children=(
+                                                HeadingNode(
+                                                    title='This is an H6',
+                                                    title_slug='this-is-an-h6',
+                                                    level=6,
+                                                    children=()
+                                                ),
+                                            )
+                                        ),
+                                    )
+                        ),
+                    )
+        self.assertTupleEqual(tree, expected_tree)
+
     def test_single_heading(self):
         '''Checks the simplist case of a single heading.
         '''
@@ -127,7 +162,7 @@ class HeadingTest(ProcessorTest):
     #~
 
     def test_doc_example_basic(self):
-        '''An example of simplistic useage.
+        '''An example of simplistic usage.
         '''
         test_string = self.read_test_file(self.processor_name, 'doc_example_basic_usage.md')
         blocks = self.to_blocks(test_string)
@@ -163,7 +198,7 @@ class HeadingTest(ProcessorTest):
 
 
     def test_doc_example_override_html(self):
-        '''An example of complex useage, involving multiple H1s
+        '''An example of complex usage, involving multiple H1s
         and shows html overriding.
         '''
         test_string = self.read_test_file(self.processor_name, 'doc_example_override_html.md')

--- a/verto/tests/PanelTest.py
+++ b/verto/tests/PanelTest.py
@@ -39,6 +39,18 @@ class PanelTest(ProcessorTest):
         expected_string = self.read_test_file(self.processor_name, 'heading_no_subtitle_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
+    def test_heading_with_punctation(self):
+        '''Tests that a heading is parsed correctly
+        '''
+        test_string = self.read_test_file(self.processor_name, 'heading_with_punctation.md')
+        blocks = self.to_blocks(test_string)
+
+        self.assertListEqual([True, False, False, True], [self.block_processor.test(blocks, block) for block in blocks], msg='"{}"'.format(test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'heading_with_punctation_expected.html', strip=True)
+        self.assertEqual(expected_string, converted_test_string)
+
     def test_heading_subtitle_false(self):
         '''Tests that a heading is parsed correctly
         '''
@@ -73,6 +85,18 @@ class PanelTest(ProcessorTest):
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
         expected_string = self.read_test_file(self.processor_name, 'heading_with_subtitle_expected.html', strip=True)
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_heading_with_subtitle_with_punctation(self):
+        '''Tests that both a heading and subtitle is parsed correctly
+        '''
+        test_string = self.read_test_file(self.processor_name, 'heading_with_subtitle_with_punctation.md')
+        blocks = self.to_blocks(test_string)
+
+        self.assertListEqual([True, False, False, False, True], [self.block_processor.test(blocks, block) for block in blocks], msg='"{}"'.format(test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'heading_with_subtitle_with_punctation_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_heading_with_subtitle_h2_heading_in_panel(self):
@@ -157,15 +181,18 @@ class PanelTest(ProcessorTest):
 
         self.assertRaises(PanelMissingSubtitleError, lambda x: markdown.markdown(x, extensions=[self.verto_extension]), test_string)
 
-    def test_incorrect_heading_incorrect_subtitle(self):
-        '''Tests that correct error raised when heading and subtitle are incorrect
+    def test_heading_subtitle_no_whitespace(self):
+        '''Tests that heading and subtitle render correctly when no
+        whitespace is given between heading level and text.
         '''
-        test_string = self.read_test_file(self.processor_name, 'incorrect_heading_incorrect_subtitle.md')
+        test_string = self.read_test_file(self.processor_name, 'heading_subtitle_no_whitespace.md')
         blocks = self.to_blocks(test_string)
 
         self.assertListEqual([True, False, False, False, True], [self.block_processor.test(blocks, block) for block in blocks], msg='"{}"'.format(test_string))
 
-        self.assertRaises(PanelMissingTitleError, lambda x: markdown.markdown(x, extensions=[self.verto_extension]), test_string)
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'heading_subtitle_no_whitespace_expected.html', strip=True)
+        self.assertEqual(expected_string, converted_test_string)
 
     def test_parses_blank(self):
         '''Tests that a blank panel is processed with empty content.

--- a/verto/tests/assets/heading/no_whitespace.md
+++ b/verto/tests/assets/heading/no_whitespace.md
@@ -1,0 +1,5 @@
+#This is an H1
+
+##This is an H2
+
+######This is an H6

--- a/verto/tests/assets/heading/no_whitespace_expected.html
+++ b/verto/tests/assets/heading/no_whitespace_expected.html
@@ -1,0 +1,18 @@
+<h1 id="this-is-an-h1">
+<span class="section_number">
+{{ chapter.number }}.
+</span>
+This is an H1
+</h1>
+<h2 id="this-is-an-h2">
+<span class="section_number">
+{{ chapter.number }}.1.
+</span>
+This is an H2
+</h2>
+<h6 id="this-is-an-h6">
+<span class="section_number">
+{{ chapter.number }}.1.0.0.0.1.
+</span>
+This is an H6
+</h6>

--- a/verto/tests/assets/panel/heading_subtitle_no_whitespace.md
+++ b/verto/tests/assets/panel/heading_subtitle_no_whitespace.md
@@ -4,6 +4,6 @@
 
 ##Subtitle
 
-This panel does have a subtitle...but both headings are incorrect
+Panel text.
 
 {panel end}

--- a/verto/tests/assets/panel/heading_subtitle_no_whitespace_expected.html
+++ b/verto/tests/assets/panel/heading_subtitle_no_whitespace_expected.html
@@ -1,0 +1,8 @@
+<div class="panel panel-note">
+<div class="panel-header">
+<strong>Heading:</strong> Subtitle
+</div>
+<div class="panel-body">
+<p>Panel text.</p>
+</div>
+</div>

--- a/verto/tests/assets/panel/heading_with_punctation.md
+++ b/verto/tests/assets/panel/heading_with_punctation.md
@@ -1,0 +1,7 @@
+{panel type="note"}
+
+# crwdns8254:0crwdne8254:0
+
+crwdns8255:0crwdne8255:0 crwdns8256:0crwdne8256:0 crwdns8257:0crwdne8257:0 crwdns8258:0crwdne8258:0
+
+{panel end}

--- a/verto/tests/assets/panel/heading_with_punctation_expected.html
+++ b/verto/tests/assets/panel/heading_with_punctation_expected.html
@@ -1,0 +1,8 @@
+<div class="panel panel-note">
+<div class="panel-header">
+<strong>crwdns8254:0crwdne8254:0</strong>
+</div>
+<div class="panel-body">
+<p>crwdns8255:0crwdne8255:0 crwdns8256:0crwdne8256:0 crwdns8257:0crwdne8257:0 crwdns8258:0crwdne8258:0</p>
+</div>
+</div>

--- a/verto/tests/assets/panel/heading_with_subtitle_with_punctation.md
+++ b/verto/tests/assets/panel/heading_with_subtitle_with_punctation.md
@@ -1,0 +1,9 @@
+{panel type="note" subtitle="true"}
+
+# Heading
+
+## crwdns8299:0crwdne8299:0
+
+This panel does have a subtitle!
+
+{panel end}

--- a/verto/tests/assets/panel/heading_with_subtitle_with_punctation_expected.html
+++ b/verto/tests/assets/panel/heading_with_subtitle_with_punctation_expected.html
@@ -1,0 +1,8 @@
+<div class="panel panel-note">
+<div class="panel-header">
+<strong>Heading:</strong> crwdns8299:0crwdne8299:0
+</div>
+<div class="panel-body">
+<p>This panel does have a subtitle!</p>
+</div>
+</div>


### PR DESCRIPTION
Also changes regular expression to match heading syntax, where a whitespace character is optional after defining the heading level.

Also adds test to heading processor for checking it works when no whitespace character is given.

Fixes #267.

### Checklist

*Change the space in the box to an `x` for those that apply. You can also fill these out after creating the pull request. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change.*

- [x] I have read the [contribution guidelines](.github/CONTRIBUTING.md)
- [x] I have linked any relevant [existing issues/suggestions](https://github.com/uccser/verto/issues) in the description above (include `#???` in your description to reference an issue, where `???` is the issue number)
- [x] I have run the test suite and all tests passed
- [x] I have added necessary documentation (if appropriate)
