### PR TITLE
Add code coverage tracking

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+branch = True
+source =
+    verto
+omit =
+    # Omit test files
+    */tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ install:
 script:
   - flake8
   - python -m verto.tests.start_tests --travis
+  - coverage run --rcfile=.coveragerc -m verto.tests.start_tests --travis
+after_success:
+  - coverage xml -i
+  - coverage report -m --skip-covered
+  - bash <(curl -s https://codecov.io/bash)
 
 # Stop email notifications but post to organisation Slack channel
 notifications:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ setuptools==40.2.0
 # Required dependencies for building documentation
 sphinx==1.7.9
 sphinx_rtd_theme==0.4.1
+
+# Coverage Tools
+coverage==4.5.1


### PR DESCRIPTION
This enables CodeCov on this repository, which is a good helper in spotting areas not covered by tests.

You can see coverage here: https://codecov.io/gh/uccser/verto/tree/code-coverage/verto