### PR TITLE
Add external link processor

### DIFF
--- a/docs/source/processors/external-link.rst
+++ b/docs/source/processors/external-link.rst
@@ -1,0 +1,22 @@
+External Link
+#######################################
+
+**Processor name:** ``external-link``
+
+This processor will find any external links (links that start with ``http:``, ``https:``, ``mailto:``, etc.), and will create a HTML link with the ``target`` attribute set to ``"_blank"``.
+This allows external links in Markdown to be opened in a new tab.
+
+The default HTML for external links is:
+
+.. literalinclude:: ../../../verto/html-templates/external-link.html
+   :language: css+jinja
+
+Using the following example tag:
+
+.. literalinclude:: ../../../verto/tests/assets/external-link/https_schema.md
+   :language: none
+
+The resulting HTML would be:
+
+.. literalinclude:: ../../../verto/tests/assets/external-link/https_schema_expected.html
+   :language: html

--- a/docs/source/processors/index.rst
+++ b/docs/source/processors/index.rst
@@ -18,6 +18,7 @@ The following pages covers how to use the available processors within Markdown t
     button-link
     comment
     conditional
+    external-link
     iframe
     glossary-link
     heading

--- a/verto/Verto.py
+++ b/verto/Verto.py
@@ -7,6 +7,7 @@ DEFAULT_PROCESSORS = frozenset({
     'button-link',
     'comment',
     'conditional',
+    'external-link',
     'glossary-link',
     'style',
     'heading',

--- a/verto/VertoExtension.py
+++ b/verto/VertoExtension.py
@@ -10,6 +10,7 @@ from verto.processors.ImageContainerBlockProcessor import ImageContainerBlockPro
 from verto.processors.InteractiveTagBlockProcessor import InteractiveTagBlockProcessor
 from verto.processors.InteractiveContainerBlockProcessor import InteractiveContainerBlockProcessor
 from verto.processors.RelativeLinkPattern import RelativeLinkPattern
+from verto.processors.ExternalLinkPattern import ExternalLinkPattern
 from verto.processors.RemoveTitlePreprocessor import RemoveTitlePreprocessor
 from verto.processors.SaveTitlePreprocessor import SaveTitlePreprocessor
 from verto.processors.GlossaryLinkPattern import GlossaryLinkPattern
@@ -192,6 +193,7 @@ class VertoExtension(Extension):
         ]
         self.inlinepatterns = [  # A special treeprocessor
             ['relative-link', RelativeLinkPattern(self, md), '_begin'],
+            ['external-link', ExternalLinkPattern(self, md), '_begin'],
             ['glossary-link', GlossaryLinkPattern(self, md), '_begin'],
             ['image-inline', ImageInlinePattern(self, md), '_begin']
         ]

--- a/verto/html-templates/external-link.html
+++ b/verto/html-templates/external-link.html
@@ -1,0 +1,1 @@
+<a href='{{ "{{ base_path }}" }}{{ link_path }}{{ link_query }}'>{{ text }}</a>

--- a/verto/html-templates/external-link.html
+++ b/verto/html-templates/external-link.html
@@ -1,1 +1,1 @@
-<a href='{{ "{{ base_path }}" }}{{ link_path }}{{ link_query }}'>{{ text }}</a>
+<a href='{{ link_path }}{{ link_query }}' target="_blank">{{ text }}</a>

--- a/verto/processor-info.json
+++ b/verto/processor-info.json
@@ -519,5 +519,9 @@
             "argument": "title"
           }
         }
+    },
+    "external-link": {
+      "class": "custom",
+      "pattern": "\\[(?P<link_text>[^\\]]+)\\]\\((?=(https?|ftps?|mailto|news):)(?P<link_url>[^\\?\\)]+)(?P<link_query>\\?[^\\)]*)?\\)"
     }
 }

--- a/verto/processors/ExternalLinkPattern.py
+++ b/verto/processors/ExternalLinkPattern.py
@@ -1,0 +1,49 @@
+from verto.utils.HtmlParser import HtmlParser
+from markdown.inlinepatterns import Pattern
+from html import escape
+import re
+
+
+class ExternalLinkPattern(Pattern):
+    '''Return a link element from the given match.
+
+    Only matches:
+        - Markdown links using []() syntax.
+        - Links that start with:
+            - http:
+            - https:
+            - ftp:
+            - ftps:
+            - mailto:
+            - news:
+    '''
+
+    def __init__(self, ext, *args, **kwargs):
+        '''
+        Args:
+            ext: An instance of the Markdown class.
+        '''
+        self.processor = 'relative-link'
+        self.pattern = ext.processor_info[self.processor]['pattern']
+        self.compiled_re = re.compile('^(.*?){}(.*)$'.format(self.pattern), re.DOTALL | re.UNICODE)
+        self.template = ext.jinja_templates[self.processor]
+
+    def handleMatch(self, match):
+        ''' Inherited from Pattern. Accepts a match and returns an
+        ElementTree element of a internal link.
+        Args:
+            match: The string of text where the match was found.
+        Returns:
+            An element tree node to be appended to the html tree.
+        '''
+        context = dict()
+        context['link_path'] = escape(match.group('link_url'))
+        link_query = match.group('link_query')
+        if link_query:
+            context['link_query'] = link_query
+        context['text'] = match.group('link_text')
+
+        html_string = self.template.render(context)
+        parser = HtmlParser()
+        parser.feed(html_string).close()
+        return parser.get_root()

--- a/verto/processors/ExternalLinkPattern.py
+++ b/verto/processors/ExternalLinkPattern.py
@@ -23,14 +23,14 @@ class ExternalLinkPattern(Pattern):
         Args:
             ext: An instance of the Markdown class.
         '''
-        self.processor = 'relative-link'
+        self.processor = 'external-link'
         self.pattern = ext.processor_info[self.processor]['pattern']
         self.compiled_re = re.compile('^(.*?){}(.*)$'.format(self.pattern), re.DOTALL | re.UNICODE)
         self.template = ext.jinja_templates[self.processor]
 
     def handleMatch(self, match):
         ''' Inherited from Pattern. Accepts a match and returns an
-        ElementTree element of a internal link.
+        ElementTree element of an external link.
         Args:
             match: The string of text where the match was found.
         Returns:

--- a/verto/tests/ExternalLinkTest.py
+++ b/verto/tests/ExternalLinkTest.py
@@ -1,0 +1,218 @@
+import markdown
+import re
+from unittest.mock import Mock
+from verto.processors.ExternalLinkPattern import ExternalLinkPattern
+from verto.tests.ProcessorTest import ProcessorTest
+
+
+class ExternalLinkTest(ProcessorTest):
+    '''Tests to check the 'external-link' pattern works as intended.
+    This class is unique to other processors as it overrides
+    default markdown behaviour in certain situations.
+    '''
+
+    def __init__(self, *args, **kwargs):
+        '''Set processor name in class for asset file retrieval.'''
+        ProcessorTest.__init__(self, *args, **kwargs)
+        self.processor_name = 'external-link'
+        self.ext = Mock()
+        self.ext.processor_info = ProcessorTest.loadProcessorInfo(self)
+        self.ext.jinja_templates = {self.processor_name: ProcessorTest.loadJinjaTemplate(self, self.processor_name)}
+
+    def test_ignore_http_schema(self):
+        '''Tests that external links starting with http are matched.'''
+        test_string = self.read_test_file(self.processor_name, 'http_schema.md')
+
+        processor = ExternalLinkPattern(self.ext, self.md.parser)
+        self.assertIsNotNone(re.search(processor.compiled_re, test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'http_schema_expected.html', strip=True).strip()
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_http_text(self):
+        '''Tests that relative links are not matched.'''
+        test_string = self.read_test_file(self.processor_name, 'http_text.md')
+
+        processor = ExternalLinkPattern(self.ext, self.md.parser)
+        self.assertIsNone(re.search(processor.compiled_re, test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'http_text_expected.html', strip=True).strip()
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_https_schema(self):
+        '''Tests that external links starting with https are matched.'''
+        test_string = self.read_test_file(self.processor_name, 'https_schema.md')
+
+        processor = ExternalLinkPattern(self.ext, self.md.parser)
+        self.assertIsNotNone(re.search(processor.compiled_re, test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'https_schema_expected.html', strip=True).strip()
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_ignore_https_text(self):
+        '''Tests that relative links are not matched.'''
+        test_string = self.read_test_file(self.processor_name, 'https_text.md')
+
+        processor = ExternalLinkPattern(self.ext, self.md.parser)
+        self.assertIsNone(re.search(processor.compiled_re, test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'https_text_expected.html', strip=True).strip()
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_ftp_schema(self):
+        '''Tests that external links starting with ftp are matched.'''
+        test_string = self.read_test_file(self.processor_name, 'ftp_schema.md')
+
+        processor = ExternalLinkPattern(self.ext, self.md.parser)
+        self.assertIsNotNone(re.search(processor.compiled_re, test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'ftp_schema_expected.html', strip=True).strip()
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_ignore_ftp_text(self):
+        '''Tests that relative links are not matched.'''
+        test_string = self.read_test_file(self.processor_name, 'ftp_text.md')
+
+        processor = ExternalLinkPattern(self.ext, self.md.parser)
+        self.assertIsNone(re.search(processor.compiled_re, test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'ftp_text_expected.html', strip=True).strip()
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_ftps_schema(self):
+        '''Tests that external links starting with ftps are matched.'''
+        test_string = self.read_test_file(self.processor_name, 'ftps_schema.md')
+
+        processor = ExternalLinkPattern(self.ext, self.md.parser)
+        self.assertIsNotNone(re.search(processor.compiled_re, test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'ftps_schema_expected.html', strip=True).strip()
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_ignore_ftps_text(self):
+        '''Tests that relative links are not matched.'''
+        test_string = self.read_test_file(self.processor_name, 'ftps_text.md')
+
+        processor = ExternalLinkPattern(self.ext, self.md.parser)
+        self.assertIsNone(re.search(processor.compiled_re, test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'ftps_text_expected.html', strip=True).strip()
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_mailto_schema(self):
+        '''Tests that external links starting with mailto are matched.'''
+        test_string = self.read_test_file(self.processor_name, 'mailto_schema.md')
+
+        processor = ExternalLinkPattern(self.ext, self.md.parser)
+        self.assertIsNotNone(re.search(processor.compiled_re, test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'mailto_schema_expected.html', strip=True).strip()
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_ignore_mailto_text(self):
+        '''Tests that relative links are not matched.'''
+        test_string = self.read_test_file(self.processor_name, 'mailto_text.md')
+
+        processor = ExternalLinkPattern(self.ext, self.md.parser)
+        self.assertIsNone(re.search(processor.compiled_re, test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'mailto_text_expected.html', strip=True).strip()
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_news_schema(self):
+        '''Tests that external links starting with news are matched.'''
+        test_string = self.read_test_file(self.processor_name, 'news_schema.md')
+
+        processor = ExternalLinkPattern(self.ext, self.md.parser)
+        self.assertIsNotNone(re.search(processor.compiled_re, test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'news_schema_expected.html', strip=True).strip()
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_ignore_news_text(self):
+        '''Tests that relative links are not matched.'''
+        test_string = self.read_test_file(self.processor_name, 'news_text.md')
+
+        processor = ExternalLinkPattern(self.ext, self.md.parser)
+        self.assertIsNone(re.search(processor.compiled_re, test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'news_text_expected.html', strip=True).strip()
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_ignore_www_text(self):
+        '''Tests that links similar to a match are not matched.'''
+        test_string = self.read_test_file(self.processor_name, 'www_text.md')
+
+        processor = ExternalLinkPattern(self.ext, self.md.parser)
+        self.assertIsNone(re.search(processor.compiled_re, test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'www_text_expected.html', strip=True).strip()
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_long_path(self):
+        '''Tests that long paths with less than 31 characters work.'''
+        test_string = self.read_test_file(self.processor_name, 'long_path.md')
+
+        processor = ExternalLinkPattern(self.ext, self.md.parser)
+        self.assertIsNotNone(re.search(processor.compiled_re, test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'long_path_expected.html', strip=True).strip()
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_query_parameter(self):
+        '''Tests that paths with query parameter work.'''
+        test_string = self.read_test_file(self.processor_name, 'query_parameter.md')
+
+        processor = ExternalLinkPattern(self.ext, self.md.parser)
+        self.assertIsNotNone(re.search(processor.compiled_re, test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'query_parameter_expected.html', strip=True).strip()
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_multiple_query_parameters(self):
+        '''Tests that paths with multiple query parameters work.'''
+        test_string = self.read_test_file(self.processor_name, 'multiple_query_parameters.md')
+
+        processor = ExternalLinkPattern(self.ext, self.md.parser)
+        self.assertIsNotNone(re.search(processor.compiled_re, test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'multiple_query_parameters_expected.html', strip=True).strip()
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_trailing_question_mark(self):
+        '''Tests paths with trailing question marks.'''
+        test_string = self.read_test_file(self.processor_name, 'trailing_question_mark.md')
+
+        processor = ExternalLinkPattern(self.ext, self.md.parser)
+        self.assertIsNotNone(re.search(processor.compiled_re, test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'trailing_question_mark_expected.html', strip=True).strip()
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_multiple_links(self):
+        '''Tests that multiple links are processed.'''
+        test_string = self.read_test_file(self.processor_name, 'multiple_links.md')
+
+        processor = ExternalLinkPattern(self.ext, self.md.parser)
+        self.assertIsNotNone(re.search(processor.compiled_re, test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'multiple_links_expected.html', strip=True).strip()
+        self.assertEqual(expected_string, converted_test_string)

--- a/verto/tests/assets/external-link/ftp_schema.md
+++ b/verto/tests/assets/external-link/ftp_schema.md
@@ -1,0 +1,1 @@
+Check out this [website](ftp://ftp.fakesite.org:21).

--- a/verto/tests/assets/external-link/ftp_schema_expected.html
+++ b/verto/tests/assets/external-link/ftp_schema_expected.html
@@ -1,0 +1,1 @@
+<p>Check out this <a href="ftp://ftp.fakesite.org:21" target="_blank">website</a>.</p>

--- a/verto/tests/assets/external-link/ftp_text.md
+++ b/verto/tests/assets/external-link/ftp_text.md
@@ -1,0 +1,1 @@
+Check out this [item](ftp/item.html).

--- a/verto/tests/assets/external-link/ftp_text_expected.html
+++ b/verto/tests/assets/external-link/ftp_text_expected.html
@@ -1,0 +1,1 @@
+<p>Check out this <a href="ftp/item.html">item</a>.</p>

--- a/verto/tests/assets/external-link/ftps_schema.md
+++ b/verto/tests/assets/external-link/ftps_schema.md
@@ -1,0 +1,1 @@
+Check out this [website](ftps://ftp.fakesite.org:21).

--- a/verto/tests/assets/external-link/ftps_schema_expected.html
+++ b/verto/tests/assets/external-link/ftps_schema_expected.html
@@ -1,0 +1,1 @@
+<p>Check out this <a href="ftps://ftp.fakesite.org:21" target="_blank">website</a>.</p>

--- a/verto/tests/assets/external-link/ftps_text.md
+++ b/verto/tests/assets/external-link/ftps_text.md
@@ -1,0 +1,1 @@
+Check out this [item](ftps/item.html).

--- a/verto/tests/assets/external-link/ftps_text_expected.html
+++ b/verto/tests/assets/external-link/ftps_text_expected.html
@@ -1,0 +1,1 @@
+<p>Check out this <a href="ftps/item.html">item</a>.</p>

--- a/verto/tests/assets/external-link/http_schema.md
+++ b/verto/tests/assets/external-link/http_schema.md
@@ -1,0 +1,1 @@
+Check out this [website](http://www.google.com).

--- a/verto/tests/assets/external-link/http_schema_expected.html
+++ b/verto/tests/assets/external-link/http_schema_expected.html
@@ -1,0 +1,1 @@
+<p>Check out this <a href="http://www.google.com" target="_blank">website</a>.</p>

--- a/verto/tests/assets/external-link/http_text.md
+++ b/verto/tests/assets/external-link/http_text.md
@@ -1,0 +1,1 @@
+Check out this [website](http.html).

--- a/verto/tests/assets/external-link/http_text_expected.html
+++ b/verto/tests/assets/external-link/http_text_expected.html
@@ -1,0 +1,1 @@
+<p>Check out this <a href="http.html">website</a>.</p>

--- a/verto/tests/assets/external-link/https_schema.md
+++ b/verto/tests/assets/external-link/https_schema.md
@@ -1,0 +1,1 @@
+Check out this [website](https://www.google.com).

--- a/verto/tests/assets/external-link/https_schema_expected.html
+++ b/verto/tests/assets/external-link/https_schema_expected.html
@@ -1,0 +1,1 @@
+<p>Check out this <a href="https://www.google.com" target="_blank">website</a>.</p>

--- a/verto/tests/assets/external-link/https_text.md
+++ b/verto/tests/assets/external-link/https_text.md
@@ -1,0 +1,1 @@
+Check out this [website](https.html).

--- a/verto/tests/assets/external-link/https_text_expected.html
+++ b/verto/tests/assets/external-link/https_text_expected.html
@@ -1,0 +1,1 @@
+<p>Check out this <a href="https.html">website</a>.</p>

--- a/verto/tests/assets/external-link/long_path.md
+++ b/verto/tests/assets/external-link/long_path.md
@@ -1,0 +1,1 @@
+Check out this [website](https://www.google.com/binary/).

--- a/verto/tests/assets/external-link/long_path_expected.html
+++ b/verto/tests/assets/external-link/long_path_expected.html
@@ -1,0 +1,1 @@
+<p>Check out this <a href="https://www.google.com/binary/" target="_blank">website</a>.</p>

--- a/verto/tests/assets/external-link/mailto_schema.md
+++ b/verto/tests/assets/external-link/mailto_schema.md
@@ -1,0 +1,1 @@
+Check out this [email](mailto:bob@example.com).

--- a/verto/tests/assets/external-link/mailto_schema_expected.html
+++ b/verto/tests/assets/external-link/mailto_schema_expected.html
@@ -1,0 +1,1 @@
+<p>Check out this <a href="mailto:bob@example.com" target="_blank">email</a>.</p>

--- a/verto/tests/assets/external-link/mailto_text.md
+++ b/verto/tests/assets/external-link/mailto_text.md
@@ -1,0 +1,1 @@
+Check out this [page](mailto.html).

--- a/verto/tests/assets/external-link/mailto_text_expected.html
+++ b/verto/tests/assets/external-link/mailto_text_expected.html
@@ -1,0 +1,1 @@
+<p>Check out this <a href="mailto.html">page</a>.</p>

--- a/verto/tests/assets/external-link/multiple_links.md
+++ b/verto/tests/assets/external-link/multiple_links.md
@@ -1,0 +1,3 @@
+This is the [first link](https://www.link1.com) and this is the [second link](https://www.link2.com).
+
+This is the [third link](https://www.link3.com).

--- a/verto/tests/assets/external-link/multiple_links_expected.html
+++ b/verto/tests/assets/external-link/multiple_links_expected.html
@@ -1,0 +1,2 @@
+<p>This is the <a href="https://www.link1.com" target="_blank">first link</a> and this is the <a href="https://www.link2.com" target="_blank">second link</a>.</p>
+<p>This is the <a href="https://www.link3.com" target="_blank">third link</a>.</p>

--- a/verto/tests/assets/external-link/multiple_query_parameters.md
+++ b/verto/tests/assets/external-link/multiple_query_parameters.md
@@ -1,0 +1,1 @@
+Check out this [website](https://www.google.com?key1=value1&key2=value2).

--- a/verto/tests/assets/external-link/multiple_query_parameters_expected.html
+++ b/verto/tests/assets/external-link/multiple_query_parameters_expected.html
@@ -1,0 +1,1 @@
+<p>Check out this <a href="https://www.google.com?key1=value1&amp;key2=value2" target="_blank">website</a>.</p>

--- a/verto/tests/assets/external-link/news_schema.md
+++ b/verto/tests/assets/external-link/news_schema.md
@@ -1,0 +1,1 @@
+Check out this [news](news://feed.news.com).

--- a/verto/tests/assets/external-link/news_schema_expected.html
+++ b/verto/tests/assets/external-link/news_schema_expected.html
@@ -1,0 +1,1 @@
+<p>Check out this <a href="news://feed.news.com" target="_blank">news</a>.</p>

--- a/verto/tests/assets/external-link/news_text.md
+++ b/verto/tests/assets/external-link/news_text.md
@@ -1,0 +1,1 @@
+Check out this [news](news).

--- a/verto/tests/assets/external-link/news_text_expected.html
+++ b/verto/tests/assets/external-link/news_text_expected.html
@@ -1,0 +1,1 @@
+<p>Check out this <a href="news">news</a>.</p>

--- a/verto/tests/assets/external-link/query_parameter.md
+++ b/verto/tests/assets/external-link/query_parameter.md
@@ -1,0 +1,1 @@
+Check out this [website](https://www.google.com?key=value).

--- a/verto/tests/assets/external-link/query_parameter_expected.html
+++ b/verto/tests/assets/external-link/query_parameter_expected.html
@@ -1,0 +1,1 @@
+<p>Check out this <a href="https://www.google.com?key=value" target="_blank">website</a>.</p>

--- a/verto/tests/assets/external-link/trailing_question_mark.md
+++ b/verto/tests/assets/external-link/trailing_question_mark.md
@@ -1,0 +1,1 @@
+Check out this [website](https://www.google.com?).

--- a/verto/tests/assets/external-link/trailing_question_mark_expected.html
+++ b/verto/tests/assets/external-link/trailing_question_mark_expected.html
@@ -1,0 +1,1 @@
+<p>Check out this <a href="https://www.google.com?" target="_blank">website</a>.</p>

--- a/verto/tests/assets/external-link/www_text.md
+++ b/verto/tests/assets/external-link/www_text.md
@@ -1,0 +1,1 @@
+Check out this [website](www.google.com).

--- a/verto/tests/assets/external-link/www_text_expected.html
+++ b/verto/tests/assets/external-link/www_text_expected.html
@@ -1,0 +1,1 @@
+<p>Check out this <a href="www.google.com">website</a>.</p>

--- a/verto/tests/start_tests.py
+++ b/verto/tests/start_tests.py
@@ -19,6 +19,7 @@ from verto.tests.InteractiveTagTest import InteractiveTagTest
 from verto.tests.InteractiveContainerTest import InteractiveContainerTest
 from verto.tests.PanelTest import PanelTest
 from verto.tests.RelativeLinkTest import RelativeLinkTest
+from verto.tests.ExternalLinkTest import ExternalLinkTest
 from verto.tests.RemoveTest import RemoveTest
 from verto.tests.RemoveTitleTest import RemoveTitleTest
 from verto.tests.SaveTitleTest import SaveTitleTest
@@ -107,6 +108,7 @@ def unit_suite():
         unittest.makeSuite(ScratchInlineTest),
         unittest.makeSuite(StyleTest),
         unittest.makeSuite(RelativeLinkTest),
+        unittest.makeSuite(ExternalLinkTest),
         unittest.makeSuite(RemoveTest),
         unittest.makeSuite(RemoveTitleTest),
         unittest.makeSuite(TableOfContentsTest),


### PR DESCRIPTION
This PR adds a custom external link processor. This processor overrides default markdown behaviour by opening external links in a new tab.

I have added some basic documentation.

This relates to https://github.com/uccser/cs-field-guide/issues/783