### PR TITLE
Rename custom_settings parameter to settings

### DIFF
--- a/verto/Verto.py
+++ b/verto/Verto.py
@@ -31,7 +31,7 @@ class Verto(object):
     to HTML.
     '''
 
-    def __init__(self, processors=DEFAULT_PROCESSORS, html_templates={}, extensions=[], custom_settings={}):
+    def __init__(self, processors=DEFAULT_PROCESSORS, html_templates={}, extensions=[], settings={}):
         '''Creates a Verto object.
 
         Args:
@@ -45,12 +45,12 @@ class Verto(object):
                 eg: {'image': '<img src={{ source }}>'}
             extensions: A list of extra extensions to run on the
                 markdown package.
-            custom_settings: A dictionary of settings to override default settings.
+            settings: A dictionary of settings to override default settings.
         '''
         self.processors = set(processors)
         self.html_templates = dict(html_templates)
         self.extensions = list(extensions)
-        self.custom_settings = custom_settings
+        self.settings = settings
         self.create_converter()
 
     def create_converter(self):
@@ -59,7 +59,7 @@ class Verto(object):
             processors=self.processors,
             html_templates=self.html_templates,
             extensions=self.extensions,
-            custom_settings=self.custom_settings,
+            settings=self.settings,
         )
         all_extensions = self.extensions + [self.verto_extension]
         self.converter = markdown.Markdown(extensions=all_extensions)

--- a/verto/VertoExtension.py
+++ b/verto/VertoExtension.py
@@ -50,7 +50,7 @@ class VertoExtension(Extension):
     the Verto converter.
     '''
 
-    def __init__(self, processors=[], html_templates={}, extensions=[], custom_settings={}, *args, **kwargs):
+    def __init__(self, processors=[], html_templates={}, extensions=[], settings={}, *args, **kwargs):
         '''
         Args:
             processors: A set of processor names given as strings for which
@@ -62,12 +62,12 @@ class VertoExtension(Extension):
                 as values.
                 eg: {'image': '<img src={{ source }}>'}
             extensions: A list of extra extensions for compatibility.
-            custom_settings: A dictionary of user settings to override defaults.
+            settings: A dictionary of user settings to override defaults.
         '''
         super().__init__(*args, **kwargs)
         self.jinja_templates = self.loadJinjaTemplates(html_templates)
         self.processors = processors
-        self.settings = self.get_settings(custom_settings)
+        self.settings = self.get_settings(settings)
         self.processor_info = self.loadProcessorInfo()
         self.title = None
         self.heading_tree = None

--- a/verto/tests/BlockquoteTest.py
+++ b/verto/tests/BlockquoteTest.py
@@ -187,7 +187,7 @@ class BlockquoteTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'source_true.md')
@@ -211,7 +211,7 @@ class BlockquoteTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'source_true_missing_argument.md')
@@ -233,7 +233,7 @@ class BlockquoteTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'alignment_true.md')
@@ -257,7 +257,7 @@ class BlockquoteTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'alignment_true_missing_argument.md')

--- a/verto/tests/BoxedTextTest.py
+++ b/verto/tests/BoxedTextTest.py
@@ -132,7 +132,7 @@ class BoxedTextTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'indented_required.md')
@@ -156,7 +156,7 @@ class BoxedTextTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'type_required.md')
@@ -181,7 +181,7 @@ class BoxedTextTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'indented_and_type_required.md')
@@ -205,7 +205,7 @@ class BoxedTextTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'indented_required_not_provided.md')
@@ -228,7 +228,7 @@ class BoxedTextTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'indented_and_type_required_type_not_provided.md')

--- a/verto/tests/ButtonLinkTest.py
+++ b/verto/tests/ButtonLinkTest.py
@@ -97,7 +97,7 @@ class ButtonLinkTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'link_false.md')
@@ -121,7 +121,7 @@ class ButtonLinkTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'text_false.md')
@@ -145,7 +145,7 @@ class ButtonLinkTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'file_true.md')
@@ -170,7 +170,7 @@ class ButtonLinkTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'text_false_file_true.md')
@@ -194,7 +194,7 @@ class ButtonLinkTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'file_true_not_provided.md')

--- a/verto/tests/ConfigurationTest.py
+++ b/verto/tests/ConfigurationTest.py
@@ -376,7 +376,7 @@ class ConfigurationTest(BaseTest):
                 }
             }
         }
-        verto = Verto(custom_settings=settings)
+        verto = Verto(settings=settings)
         self.assertEqual(
             verto.verto_extension.settings['processor_argument_overrides'],
             dict(settings['processor_argument_overrides'])
@@ -395,7 +395,7 @@ class ConfigurationTest(BaseTest):
                 },
             }
         }
-        verto = Verto(custom_settings=settings)
+        verto = Verto(settings=settings)
         self.assertEqual(
             verto.verto_extension.settings['processor_argument_overrides'],
             dict(settings['processor_argument_overrides'])
@@ -419,7 +419,7 @@ class ConfigurationTest(BaseTest):
             }
         }
         processors = {'image-tag', 'panel', 'comment'}
-        verto = VertoExtension(processors=processors, custom_settings=settings)
+        verto = VertoExtension(processors=processors, settings=settings)
 
         test_string = self.read_test_file(self.test_name, 'custom_argument_rules_multiple_tags_error.md')
         self.assertRaises(ArgumentMissingError, lambda x: markdown.markdown(x, extensions=[verto]), test_string)
@@ -441,7 +441,7 @@ class ConfigurationTest(BaseTest):
 
         self.assertRaises(
             CustomArgumentRulesError,
-            lambda: VertoExtension(processors=processors, custom_settings=settings)
+            lambda: VertoExtension(processors=processors, settings=settings)
         )
 
     def test_custom_argument_rules_incorrect_processor_argument_error(self):
@@ -461,5 +461,5 @@ class ConfigurationTest(BaseTest):
 
         self.assertRaises(
             CustomArgumentRulesError,
-            lambda: VertoExtension(processors=processors, custom_settings=settings)
+            lambda: VertoExtension(processors=processors, settings=settings)
         )

--- a/verto/tests/FrameTest.py
+++ b/verto/tests/FrameTest.py
@@ -60,7 +60,7 @@ class FrameTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'link_false.md')

--- a/verto/tests/GlossaryLinkTest.py
+++ b/verto/tests/GlossaryLinkTest.py
@@ -207,7 +207,7 @@ class GlossaryLinkTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'reference_text_true_not_provided.md')

--- a/verto/tests/ImageContainerTest.py
+++ b/verto/tests/ImageContainerTest.py
@@ -460,7 +460,7 @@ class ImageContainerTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'alt_false.md')
@@ -490,7 +490,7 @@ class ImageContainerTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'hover_true.md')
@@ -521,7 +521,7 @@ class ImageContainerTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'alt_false_source_true.md')
@@ -551,7 +551,7 @@ class ImageContainerTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'hover_true_not_provided.md')

--- a/verto/tests/ImageInlineTest.py
+++ b/verto/tests/ImageInlineTest.py
@@ -333,7 +333,7 @@ class ImageInlineTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'alt_false.md')
@@ -362,7 +362,7 @@ class ImageInlineTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
 
@@ -393,7 +393,7 @@ class ImageInlineTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'alt_false_source_true.md')
@@ -422,7 +422,7 @@ class ImageInlineTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'hover_true_not_provided.md')

--- a/verto/tests/ImageTagTest.py
+++ b/verto/tests/ImageTagTest.py
@@ -401,7 +401,7 @@ class ImageTagTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'alt_false.md')
@@ -431,7 +431,7 @@ class ImageTagTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'hover_true.md')
@@ -462,7 +462,7 @@ class ImageTagTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'alt_false_source_true.md')
@@ -493,7 +493,7 @@ class ImageTagTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'hover_true_not_provided.md')

--- a/verto/tests/InteractiveContainerTest.py
+++ b/verto/tests/InteractiveContainerTest.py
@@ -327,7 +327,7 @@ class InteractiveContainerTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'parameters_true.md')
@@ -351,7 +351,7 @@ class InteractiveContainerTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'thumbnail_true.md')
@@ -375,7 +375,7 @@ class InteractiveContainerTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'text_true_not_provided.md')
@@ -398,7 +398,7 @@ class InteractiveContainerTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'parameters_and_thumbnail_true.md')
@@ -426,7 +426,7 @@ class InteractiveContainerTest(ProcessorTest):
         '''Test the thumbnail for a whole page interactive is not required when overriden.'''
         verto_extension_default_thumbnail_override = VertoExtension(
             processors=[self.processor_name],
-            custom_settings={
+            settings={
                 'add_default_interactive_thumbnails_to_required_files': False}
         )
         test_string = self.read_test_file(self.processor_name, 'whole_page_without_thumbnail_parameter.md')
@@ -452,7 +452,7 @@ class InteractiveContainerTest(ProcessorTest):
         '''Test the custom thumbnail for a whole page interactive is not required when overriden.'''
         verto_extension_custom_thumbnail_override = VertoExtension(
             processors=[self.processor_name],
-            custom_settings={
+            settings={
                 'add_custom_interactive_thumbnails_to_required_files': False}
         )
         test_string = self.read_test_file(self.processor_name, 'whole_page_with_thumbnail_parameter.md')

--- a/verto/tests/InteractiveTagTest.py
+++ b/verto/tests/InteractiveTagTest.py
@@ -145,7 +145,7 @@ class InteractiveTagTest(ProcessorTest):
         '''Test the thumbnail for a whole page interactive is not required when overriden.'''
         verto_extension_default_thumbnail_override = VertoExtension(
             processors=[self.processor_name],
-            custom_settings={'add_default_interactive_thumbnails_to_required_files': False}
+            settings={'add_default_interactive_thumbnails_to_required_files': False}
         )
         test_string = self.read_test_file(self.processor_name, 'whole_page_without_thumbnail_parameter.md')
         converted_test_string = markdown.markdown(test_string, extensions=[verto_extension_default_thumbnail_override])
@@ -170,7 +170,7 @@ class InteractiveTagTest(ProcessorTest):
         '''Test the custom thumbnail for a whole page interactive is not required when overriden.'''
         verto_extension_custom_thumbnail_override = VertoExtension(
             processors=[self.processor_name],
-            custom_settings={'add_custom_interactive_thumbnails_to_required_files': False}
+            settings={'add_custom_interactive_thumbnails_to_required_files': False}
         )
         test_string = self.read_test_file(self.processor_name, 'whole_page_with_thumbnail_parameter.md')
         converted_test_string = markdown.markdown(test_string, extensions=[verto_extension_custom_thumbnail_override])
@@ -191,7 +191,7 @@ class InteractiveTagTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'parameters_true.md')
@@ -215,7 +215,7 @@ class InteractiveTagTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
 
@@ -241,7 +241,7 @@ class InteractiveTagTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'parameters_and_thumbnail_true.md')

--- a/verto/tests/PanelTest.py
+++ b/verto/tests/PanelTest.py
@@ -380,7 +380,7 @@ class PanelTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'type_false.md')
@@ -404,7 +404,7 @@ class PanelTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'subtitle_true.md')
@@ -428,7 +428,7 @@ class PanelTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'expanded_true.md')
@@ -452,7 +452,7 @@ class PanelTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'subtitle_true_not_provided.md')

--- a/verto/tests/VideoTest.py
+++ b/verto/tests/VideoTest.py
@@ -198,7 +198,7 @@ class VideoTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'url_false.md')
@@ -222,7 +222,7 @@ class VideoTest(ProcessorTest):
         }
         verto_extension_custom_rules = VertoExtension(
             processors=[self.processor_name],
-            custom_settings=settings
+            settings=settings
         )
 
         test_string = self.read_test_file(self.processor_name, 'title_true_not_provided.md')


### PR DESCRIPTION
Resolves #379 

Note that the documentation already states that the parameter is `settings` (not `custom_settings` as it was before this PR), so the documentation does not need to be updated.