### PR TITLE
Image fix

### DIFF
--- a/docs/source/processors/image-inline.rst
+++ b/docs/source/processors/image-inline.rst
@@ -19,11 +19,12 @@ Required Tag Parameters
 
     - Each file-path provided is added to the ``images`` set in required files stored by Verto. The set of filepaths can be accessed after conversion, see :ref:`accessing_verto_data`.
     - **Note:** If the given link is a relative (a link that doesn't start with ``http:``), the link will be rendered with a Django static command. For example, the link ``images/example.png`` would be rendered as ``{% static 'images/example.png' %}`` This can be overriden, see the override section below.
+    
+- ``alt`` - Description text of the image used when an image is not displayed, or can be read when using a screen reader (for those with reading difficulties).
 
 Optional Tag Parameters
 ***************************************
 
-- ``alt`` - Description text of the image used when an image is not displayed, or can be read when using a screen reader (for those with reading difficulties).
 - ``caption`` - Lists the given text as a caption under the image.
 - ``caption-link`` (requires caption parameter) - Converts the caption text into a link to the given caption link URL.
 - ``source`` (optional) - Adds the text 'Source' under the image with a link to the given source URL. Displays after the caption if a caption is given.

--- a/docs/source/processors/image.rst
+++ b/docs/source/processors/image.rst
@@ -7,7 +7,7 @@ You can include an image using the following text tag:
 
 .. code-block:: none
 
-    {image file-path="http://placehold.it/350x150" caption="true"}
+    {image file-path="http://placehold.it/350x150" caption="true" alt="placeholder 350x150"}
 
     This is the caption text.
 
@@ -20,7 +20,7 @@ If a caption is not needed, an end tag is not required (see example below).
 
 .. code-block:: none
 
-    {image file-path="http://placehold.it/350x150" caption="false"}
+    {image file-path="http://placehold.it/350x150" caption="false" alt="placeholder 350x150"}
 
 
 Required Tag Parameters
@@ -31,10 +31,10 @@ Required Tag Parameters
     - Each file-path provided is added to the ``images`` set in required files stored by Verto. The set of filepaths can be accessed after conversion, see :ref:`accessing_verto_data`.
     - **Note:** If the given link is a relative (a link that doesn't start with ``http:``), the link will be rendered with a Django static command. For example, the link ``images/example.png`` would be rendered as ``{% static 'images/example.png' %}`` This can be overriden, see the override section below.
 
+- ``alt`` - Description text of the image used when an image is not displayed, or can be read when using a screen reader (for those with reading difficulties).
+
 Optional Tag Parameters
 ***************************************
-
-- ``alt`` - Description text of the image used when an image is not displayed, or can be read when using a screen reader (for those with reading difficulties).
 
 - ``caption`` - Boolean flag to indicate whether the image should display a caption.
 

--- a/docs/source/processors/image.rst
+++ b/docs/source/processors/image.rst
@@ -7,7 +7,7 @@ You can include an image using the following text tag:
 
 .. code-block:: none
 
-    {image file-path="http://placehold.it/350x150" caption="true" alt="placeholder 350x150"}
+    {image file-path="https://via.placeholder.com/350x150" caption="true" alt="placeholder 350x150"}
 
     This is the caption text.
 
@@ -20,7 +20,7 @@ If a caption is not needed, an end tag is not required (see example below).
 
 .. code-block:: none
 
-    {image file-path="http://placehold.it/350x150" caption="false" alt="placeholder 350x150"}
+    {image file-path="http://via.placeholder.com/350x150" caption="false" alt="placeholder 350x150"}
 
 
 Required Tag Parameters

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 setuptools==56.2.0
-sphinx==4.0.2
+sphinx==4.2.0
 sphinx_rtd_theme==0.5.2
 coverage==5.5
 flake8==3.9.2


### PR DESCRIPTION
Fixes #581. Changes alt to be a required argument in both the documentation of image and image-inline, and in any examples in the docs. Also updates sphinx to 4.2.0 to add support for python3.10