### PR TITLE
Add minimum requirement of Python 3.8

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v2.2.2
         with:
-          python-version: '3.x'
+          python-version: '3.9'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v2.2.2
         with:
-          python-version: '3.x'
+          python-version: '3.9'
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
       - name: Checkout

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ project_urls =
 
 [options]
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.8
 include_package_data = True
 install_requires =
     markdown==2.6.11


### PR DESCRIPTION
Closes #588. This commit removes support for Python 3.6, as it is EOL, and it was causing issues with the flake8 linter. Additionally, the version of importlib-metadata has been pinned, again to deal with flake8, to a version that isn't supported by Python 3.6. The version used in the documentation and publish github actions has been fixed to python 3.9, as python 3.11 was causing issues with dependencies.