### PR TITLE
Add test containing both open and close brackets in external link

### DIFF
--- a/verto/tests/ExternalLinkTest.py
+++ b/verto/tests/ExternalLinkTest.py
@@ -206,6 +206,17 @@ class ExternalLinkTest(ProcessorTest):
         expected_string = self.read_test_file(self.processor_name, 'trailing_question_mark_expected.html', strip=True).strip()
         self.assertEqual(expected_string, converted_test_string)
 
+    def test_both_brackets(self):
+        '''Tests path containing both ().'''
+        test_string = self.read_test_file(self.processor_name, 'both_brackets.md')
+
+        processor = ExternalLinkPattern(self.ext, self.md.parser)
+        self.assertIsNotNone(re.search(processor.compiled_re, test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.verto_extension])
+        expected_string = self.read_test_file(self.processor_name, 'both_brackets_expected.html', strip=True).strip()
+        self.assertEqual(expected_string, converted_test_string)
+
     def test_multiple_links(self):
         '''Tests that multiple links are processed.'''
         test_string = self.read_test_file(self.processor_name, 'multiple_links.md')

--- a/verto/tests/assets/external-link/both_brackets.md
+++ b/verto/tests/assets/external-link/both_brackets.md
@@ -1,0 +1,1 @@
+Check out this [website](https://en.wikipedia.org/wiki/Entropy_(information_theory)).

--- a/verto/tests/assets/external-link/both_brackets_expected.html
+++ b/verto/tests/assets/external-link/both_brackets_expected.html
@@ -1,0 +1,1 @@
+<p>Check out this <a href="https://en.wikipedia.org/wiki/Entropy_(information_theory)" target="_blank">website</a>.</p>


### PR DESCRIPTION
## Proposed changes

- [x] Add test for external link containing `()`
- [ ] Update python-markdown to 3.0 or greater

Fixes https://github.com/uccser/verto/issues/657

